### PR TITLE
Add Custom Validation to company email Address (When Present)

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -17,6 +17,7 @@ class CompaniesController < ApplicationController
     if @company.save
       redirect_to companies_path, notice: "Saved"
     else
+      flash[:errors] = @company.errors.full_messages.join(', ')
       render :new
     end
   end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,6 +1,18 @@
 class Company < ApplicationRecord
+
+	CUSTOM_EMAIL_ALLOWED= true
+
 	has_paper_trail
   has_rich_text :description
 
+  validate :email_check
+
+  private
+
+  def email_check
+    if (CUSTOM_EMAIL_ALLOWED) and (email.split("@").last != "getmainstreet.com")
+      errors.add(:email, 'Sorry! Only getmainstreet.com users are allowed to register at this time')
+    end unless email.blank?
+  end
 
 end

--- a/test/controllers/companies_controller_test.rb
+++ b/test/controllers/companies_controller_test.rb
@@ -47,7 +47,7 @@ class CompaniesControllerTest < ApplicationSystemTestCase
       fill_in("company_name", with: "New Test Company")
       fill_in("company_zip_code", with: "28173")
       fill_in("company_phone", with: "5553335555")
-      fill_in("company_email", with: "new_test_company@test.com")
+      fill_in("company_email", with: "new_test_company@getmainstreet.com")
       click_button "Create Company"
     end
 
@@ -63,5 +63,19 @@ class CompaniesControllerTest < ApplicationSystemTestCase
     assert_equal "New Test Company", last_company.name
     assert_equal "28173", last_company.zip_code
   end
+
+test "Valid Email for Company" do
+  visit new_company_path
+
+  within("form#new_company") do
+    fill_in("company_name", with: "wrong Email Company")
+    fill_in("company_zip_code", with: "28173")
+    fill_in("company_phone", with: "5553335555")
+    fill_in("company_email", with: "new_test_company@getmainstreet.com")
+    assert_no_difference('Company.count') do
+      click_button 'Create Company'
+    end
+  end
+end
 
 end


### PR DESCRIPTION
All email addresses for new companies should only be a @getmainstreet.com domain. A custom error should render when attempting to create or update a company when the email does not match this domain. This should only be when email is present. Blank emails can be ignored.