### PR TITLE
☐ Add City State To Companies from Zip Code.

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -6,13 +6,25 @@ class Company < ApplicationRecord
   has_rich_text :description
 
   validate :email_check
+  after_save_commit :set_city_and_state
+
+  after_initialize :set_city_and_state
 
   private
 
   def email_check
     if (CUSTOM_EMAIL_ALLOWED) and (email.split("@").last != "getmainstreet.com")
+ #TODO: We can i18n for message
       errors.add(:email, 'Sorry! Only getmainstreet.com users are allowed to register at this time')
     end unless email.blank?
   end
+
+  def set_city_and_state
+	zipcode_details = ZipCodes.identify(zip_code)
+    unless zipcode_details.nil?
+	    self.city = zipcode_details[:city]
+	    self.state = zipcode_details[:state_code]
+		end
+	end
 
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -20,6 +20,7 @@ class Company < ApplicationRecord
   end
 
   def set_city_and_state
+  	puts 'agarwal'
 	zipcode_details = ZipCodes.identify(zip_code)
     unless zipcode_details.nil?
 	    self.city = zipcode_details[:city]

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -8,7 +8,7 @@
       <%= link_to "Edit", edit_company_path %>
     </div>
     <div class="col text-right">
-      <%= link_to "Delete", company_path, method: 'delete' %>
+      <%= link_to "Delete", company_path, method: 'delete', data: { confirm: "Are you sure?" } %>
     </div>
   </div>
   <div class="bg-success">

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -8,14 +8,14 @@
       <%= link_to "Edit", edit_company_path %>
     </div>
     <div class="col text-right">
-      <%= link_to "Delete", company_path, method: 'delete', data: {confirm: "Are you sure?"}%>
+      <%= link_to "Delete", company_path, method: 'delete' %>
     </div>
   </div>
   <div class="bg-success">
     <div class="container p-5 text-white">
       <h1><%= @company.name %></h1>
       <h3>City, State</h3>
-      <pre>☝️ This is what needs to be udpated. Examples: Atlanta, GA or Nashvile, TN</pre>
+      <pre><%= @company.city%>, <%= @company.state%></pre>
     </div>
   </div>
   <% if @company.description.present? %>

--- a/db/migrate/20200614115053_add_state_and_city_to_company.rb
+++ b/db/migrate/20200614115053_add_state_and_city_to_company.rb
@@ -1,0 +1,6 @@
+class AddStateAndCityToCompany < ActiveRecord::Migration[6.0]
+  def change
+  	add_column :companies, :city, :string
+    add_column :companies, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_14_110431) do
+ActiveRecord::Schema.define(version: 2020_06_14_115053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2020_06_14_110431) do
     t.string "zip_code"
     t.string "phone"
     t.string "email"
+    t.string "city"
+    t.string "state"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/test/controllers/companies_controller_test.rb
+++ b/test/controllers/companies_controller_test.rb
@@ -78,4 +78,19 @@ test "Valid Email for Company" do
   end
 end
 
+test "Update: city and state after zipcode update" do
+
+    within("form#edit_company_#{@company.id}") do
+      fill_in("company_zip_code", with: "30301")
+      click_button "Update Company"
+    end
+
+    assert_text "Changes Saved"
+
+    @company.reload
+    assert_equal "30301", @company.zip_code
+    assert_equal "Atlanta", @company.city
+    assert_equal "GA", @company.state
+  end
+
 end

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -1,35 +1,35 @@
 hometown_painting:
   name: Hometown Painting
-  email: "hometown_painting@hometown_painting.com"
+  email: "hometown_painting@getmainstreet.com"
   zip_code: "93003"
   phone: "555-808-8888"
 
 wolf_painting:
   name: "Wolf Painting"
-  email: "wolf_painting@wolf_painting.com"
+  email: "wolf_painting@getmainstreet.com"
   zip_code: "30301"
   phone: "555-808-8888"
 
 thompson_patining:
   name: "Thompson Family Painting"
-  email: "thompson_patining@thompson_patining.com"
+  email: "thompson_patining@getmainstreet.com"
   zip_code: "37201"
   phone: "555-808-8888"
 
 armstrong_painting:
   name: "Armstrong Painting"
-  email: "armstrong_painting@armstrong_painting.com"
+  email: "armstrong_painting@getmainstreet.com"
   zip_code:
   phone: "555-808-8888"
 
 marcus_painting:
   name: "Marcus Paint"
-  email: "marcus_painting@marcus_painting.com"
+  email: "marcus_painting@getmainstreet.com"
   zip_code:
   phone: "555-808-8888"
 
 brown_painting:
   name: "Brown Residential Painting"
-  email: "brown_painting@brown_painting.com"
+  email: "brown_painting@getmainstreet.com"
   zip_code:
   phone: "555-808-8888"


### PR DESCRIPTION
For each company "Show" page there is a placeholder for the City, State for that company. You'll need to leverage the zip code to have that value render the actual City, State. For example: Nashville, TN. It is strongly recommended to use the ZipCodes gem that is already in this project.

Every time the company's zip code is updated this city and state should be updated.

The City and State should be added as attributes to the Company object.